### PR TITLE
Fix: Notice_POST 시 body에 user 필수 포함 사항 제거 및 결과값에는 user가 나올 수 있게 하는 기능 구현

### DIFF
--- a/notice/serializers.py
+++ b/notice/serializers.py
@@ -12,6 +12,10 @@ class NoticeSerializer(serializers.ModelSerializer):
         fields = '__all__'
         
 class NoticeCreateSerializer(serializers.ModelSerializer):
+    notice_user = serializers.SerializerMethodField()
+    
+    def get_notice_user(self, obj):
+        return obj.user.username
     class Meta:
         model = Notice
-        fields = ("title", "content", "category")
+        fields = ("title", "content", "category", "notice_user",)

--- a/notice/views.py
+++ b/notice/views.py
@@ -15,9 +15,9 @@ class NoticeView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
     
     def post(self, request):
-        serializer = NoticeSerializer(data=request.data)
+        serializer = NoticeCreateSerializer(data=request.data)
         if serializer.is_valid():
-            serializer.save()
+            serializer.save(user=request.user)
             return Response(serializer.data, status=status.HTTP_200_OK)
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)       


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/notice > develop

## 변경 사항
1. NoticeCreateSerializer 수정
2. views.py 시리얼라이저 NoticeCreateSerializer 로 사용, serializer.save() > user=request.user로 수정


## 테스트 결과
![image](https://user-images.githubusercontent.com/113073174/206127798-46de0f69-0cf5-45c9-9d71-06ede4757473.png)
