### PR TITLE
Feat: fanart board 검색기능 #4

### DIFF
--- a/fanart/serializers.py
+++ b/fanart/serializers.py
@@ -57,6 +57,9 @@ class UsersampleSerializer(serializers.ModelSerializer):
 class FanartGetListSerializer(serializers.ModelSerializer):
     image = FanartImageGetSerializer()
     user = UsersampleSerializer()
+    webtoon= serializers.SerializerMethodField()
+    def get_webtoon(self, obj):
+        return obj.webtoon.title
     class Meta:
         model = Fanart
         fields = '__all__'

--- a/fanart/urls.py
+++ b/fanart/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path("baseimage/", views.BaseImageView.as_view()),
     path("colorization/", views.ColorizationView.as_view()),
     path("", views.FanartListView.as_view()),
+    path("search/<int:webtoon_id>/",views.FanartWebtoonListView.as_view()),
     path("<int:fanart_id>/", views.FanartView.as_view()),
     path("<int:fanart_id>/comment/", views.FanartCommentView.as_view()),
     path("<int:fanart_id>/comment/<int:comment_id>", views.FanartCommentView.as_view())

--- a/fanart/views.py
+++ b/fanart/views.py
@@ -70,9 +70,25 @@ class FanartListView(APIView):
         else:
             return Response(serializer.errors,status=status.HTTP_400_BAD_REQUEST)
     def get(self, request):
+        serializer_list = []
         fanart = Fanart.objects.all()
         serializer = FanartGetListSerializer(fanart, many=True)
-        return Response(serializer.data,status=status.HTTP_200_OK)
+        serializer_list.append(serializer.data)
+        fanart_likes = Fanart.objects.all()
+        serializer_likes = FanartGetListSerializer(fanart_likes,many=True)
+        serializer_list.append(serializer_likes.data)
+        return Response(serializer_list,status=status.HTTP_200_OK)
+
+class FanartWebtoonListView(APIView):
+    def get(self, request, webtoon_id):
+        serializer_list = []
+        fanart = Fanart.objects.filter(webtoon_id=webtoon_id)
+        serializer = FanartGetListSerializer(fanart, many=True)
+        serializer_list.append(serializer.data)
+        fanart_likes = Fanart.objects.all()
+        serializer_likes = FanartGetListSerializer(fanart_likes,many=True)
+        serializer_list.append(serializer_likes.data)
+        return Response(serializer_list,status=status.HTTP_200_OK)
 
 class FanartView(APIView):
 
@@ -111,3 +127,4 @@ class FanartCommentView(APIView):
         comment = FanartComment.objects.get(id=comment_id)
         comment.delete()
         return Response("삭제완료",status=status.HTTP_200_OK)
+


### PR DESCRIPTION
- 검색했을 때 일치하는 게시글만 리턴

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/fanart-search -> develop

## 변경 사항
1. 검색한 웹툰에대한 게시글과, 전체 게시글을 serializer_list 형태로 리턴

